### PR TITLE
Fix c3d on python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,3 +77,35 @@ jobs:
     - name: Run Unittests with pytest
       run: |
         pytest 
+
+  build39:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest mock
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install package
+      run: |
+        pip install -e .
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude Multiprocessing,HPC
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude Multiprocessing,HPC
+    - name: Test Docstrings with pytest
+      run: |
+        pytest --doctest-modules --continue-on-collection-errors --ignore=HPC/ --ignore=Multiprocessing/
+    - name: Run Unittests with pytest
+      run: |
+        pytest

--- a/HPC/c3d.py
+++ b/HPC/c3d.py
@@ -21,7 +21,12 @@
 '''A Python library for reading and writing C3D files.'''
 
 import array
-import cStringIO
+try:
+    from cStringIO import StringIO as FileIO
+    pyver = 2
+except:
+    from io import BytesIO as FileIO
+    pyver = 3
 import numpy as np
 import operator
 import struct
@@ -213,7 +218,7 @@ class Param(object):
                  desc='',
                  bytes_per_element=1,
                  dimensions=None,
-                 bytes='',
+                 param_bytes=b'',
                  handle=None):
         '''Set up a new parameter with at least a name.
 
@@ -238,7 +243,9 @@ class Param(object):
         self.desc = desc
         self.bytes_per_element = bytes_per_element
         self.dimensions = dimensions or []
-        self.bytes = bytes
+        self.bytes = param_bytes
+        if pyver == 2:
+            self.bytes = bytes(param_bytes)
 
         if handle:
             self.read(handle)
@@ -353,7 +360,10 @@ class Param(object):
         assert self.dimensions, \
             '{}: cannot get value as {} array!'.format(self.name, fmt)
         elems = array.array(fmt)
-        elems.fromstring(self.bytes)
+        if pyver == 2:
+            elems.fromstring(self.bytes)
+        else:
+            elems.frombytes(self.bytes)
         return np.array(elems).reshape(self.dimensions)
 
     @property
@@ -754,7 +764,7 @@ class Reader(Manager):
         # boundary issues.
         bytes = self._handle.read(512 * parameter_blocks - 4)
         while bytes:
-            buf = cStringIO.StringIO(bytes)
+            buf = FileIO(bytes)
 
             chars_in_name, group_id = struct.unpack('bb', buf.read(2))
             if group_id == 0 or chars_in_name == 0:

--- a/Multiprocessing/c3d.py
+++ b/Multiprocessing/c3d.py
@@ -21,7 +21,13 @@
 '''A Python library for reading and writing C3D files.'''
 
 import array
-import cStringIO
+try:
+    import cStringIO as FileIO
+    pyver = 2
+except:
+    from io import BytesIO as FileIO
+    pyver = 3
+
 import numpy as np
 import operator
 import struct
@@ -213,7 +219,7 @@ class Param(object):
                  desc='',
                  bytes_per_element=1,
                  dimensions=None,
-                 bytes='',
+                 param_bytes=b'',
                  handle=None):
         '''Set up a new parameter with at least a name.
 
@@ -238,7 +244,9 @@ class Param(object):
         self.desc = desc
         self.bytes_per_element = bytes_per_element
         self.dimensions = dimensions or []
-        self.bytes = bytes
+        self.bytes = param_bytes
+        if pyver == 2:
+            self.bytes = bytes(param_bytes)
 
         if handle:
             self.read(handle)
@@ -353,7 +361,10 @@ class Param(object):
         assert self.dimensions, \
             '{}: cannot get value as {} array!'.format(self.name, fmt)
         elems = array.array(fmt)
-        elems.fromstring(self.bytes)
+        if pyver == 2:
+            elems.fromstring(self.bytes)
+        else:
+            elems.frombytes(self.bytes)
         return np.array(elems).reshape(self.dimensions)
 
     @property
@@ -754,7 +765,7 @@ class Reader(Manager):
         # boundary issues.
         bytes = self._handle.read(512 * parameter_blocks - 4)
         while bytes:
-            buf = cStringIO.StringIO(bytes)
+            buf = FileIO(bytes)
 
             chars_in_name, group_id = struct.unpack('bb', buf.read(2))
             if group_id == 0 or chars_in_name == 0:

--- a/pyCGM_Single/c3dpy3.py
+++ b/pyCGM_Single/c3dpy3.py
@@ -214,7 +214,7 @@ class Param(object):
                  desc='',
                  bytes_per_element=1,
                  dimensions=None,
-                 bytes='',
+                 bytes=b'',
                  handle=None):
         '''Set up a new parameter with at least a name.
 
@@ -299,7 +299,7 @@ class Param(object):
         self.bytes_per_element, = struct.unpack('b', handle.read(1))
         dims, = struct.unpack('B', handle.read(1))
         self.dimensions = [struct.unpack('B', handle.read(1))[0] for _ in range(dims)]
-        self.bytes = ''
+        self.bytes = b''
         if self.total_bytes:
             self.bytes = handle.read(self.total_bytes)
         size, = struct.unpack('B', handle.read(1))
@@ -354,7 +354,7 @@ class Param(object):
         assert self.dimensions, \
             '{}: cannot get value as {} array!'.format(self.name, fmt)
         elems = array.array(fmt)
-        elems.fromstring(self.bytes)
+        elems.frombytes(self.bytes)
         return np.array(elems).reshape(self.dimensions)
 
     @property


### PR DESCRIPTION
### Summary of PR:
Make pyCGM work on python 3.9

### What issues does this PR close:
pyCGM was not working on python 3.9

### What files were changed and what changes were made?
- c3d.py: Add check for python and use the new reader instead of the deprecated ones.
- python-package.yml: Run unit tests on Python 3.9 to ensure that it works.

### Does your PR (check all that applies):
- Change/Remove code

### Are there any errors/relevant logs in your code?
No

### How has this been tested?
Ran doctests and unit tests.