### PR TITLE
Refactor elbowJointCenter to 4x4 version

### DIFF
--- a/pyCGM_Single/pyCGM.py
+++ b/pyCGM_Single/pyCGM.py
@@ -1460,9 +1460,9 @@ def calc_elbow_axis(relb, lelb, rwra, rwrb, lwra, lwrb, r_shoulder_jc, l_shoulde
         lwrb : array
             1x3 LWRB marker
         r_shoulder_jc : ndarray
-            A 4x4 identity matrix that holds the right shoulder joint_center
+            A 4x4 identity matrix that holds the right shoulder joint center
         l_shoulder_jc : ndarray
-            A 4x4 identity matrix that holds the left shoulder joint_center
+            A 4x4 identity matrix that holds the left shoulder joint center
         r_elbow_width : float
             The width of the right elbow
         l_elbow_width : float
@@ -1472,7 +1472,7 @@ def calc_elbow_axis(relb, lelb, rwra, rwrb, lwra, lwrb, r_shoulder_jc, l_shoulde
         l_wrist_width : float
             The width of the left wrist
         mm : float
-            The thickness of the marker in millimeters.
+            The thickness of the marker in millimeters
 
         Returns
         -------


### PR DESCRIPTION
### Summary of PR:
Replace elbowJointCenter with calc_elbow_axis. Modify jointAngleCalc to handle the returned matrices.

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- pyCGM.py - Replace function, jointAngleCalc changes

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [ ] Change/Remove tests
- [ ] Add code
- [x] Change/Remove code
- [ ] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
Ran refactored code and asserted allclose with correct output.

### Docstring: calc_elbow_axis
![calc_elbow_axis](https://user-images.githubusercontent.com/50923525/128411315-f99166f6-15c2-4023-b03e-eb9e7fd3aafe.png)




