### PR TITLE
Refactor static getDist

### DIFF
--- a/pyCGM_Single/pycgmStatic.py
+++ b/pyCGM_Single/pycgmStatic.py
@@ -68,37 +68,38 @@ def rotmat(x=0,y=0,z=0):
 
     return Rxyz
 
-def getDist(p0, p1):
-    """Get Distance function
+def get_dist(p0, p1):
+    """Get Distance
 
     This function calculates the distance between two 3-D positions.
 
     Parameters
     ----------
     p0 : array
-        Position of first x, y, z coordinate.
+        Position of first (x, y, z) coordinate.
     p1 : array
-        Position of second x, y, z coordinate.
+        Position of second (x, y, z) coordinate.
 
     Returns
     -------
-    float
+    distance : float
         The distance between positions p0 and p1.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from .pycgmStatic import getDist
+    >>> from .pycgmStatic import get_dist
     >>> p0 = [0,1,2]
     >>> p1 = [1,2,3]
-    >>> np.around(getDist(p0,p1), 2)
+    >>> np.around(get_dist(p0,p1), 2)
     1.73
     >>> p0 = np.array([991.45, 741.95, 321.36])
     >>> p1 = np.array([117.09, 142.24, 481.95])
-    >>> np.around(getDist(p0,p1), 2)
+    >>> np.around(get_dist(p0,p1), 2)
     1072.36
     """
-    return sqrt((p0[0] - p1[0])**2 + (p0[1] - p1[1])**2 + (p0[2] - p1[2])**2)
+    distance = sqrt((p0[0] - p1[0])**2 + (p0[1] - p1[1])**2 + (p0[2] - p1[2])**2)
+    return distance
 
 def getStatic(motionData,vsk,flat_foot=False,GCS=None):
     """ Get Static Offset function
@@ -193,8 +194,8 @@ def getStatic(motionData,vsk,flat_foot=False,GCS=None):
                 RKNE = frame['RKNE']
                 LKNE = frame['LKNE']
 
-                Rdst = getDist(RKNE,RMKN)
-                Ldst = getDist(LKNE,LMKN)
+                Rdst = get_dist(RKNE,RMKN)
+                Ldst = get_dist(LKNE,LMKN)
                 Rwidth.append(Rdst)
                 Lwidth.append(Ldst)
 
@@ -222,8 +223,8 @@ def getStatic(motionData,vsk,flat_foot=False,GCS=None):
                 RANK = frame['RANK']
                 LANK = frame['LANK']
 
-                Rdst = getDist(RMMA,RANK)
-                Ldst = getDist(LMMA,LANK)
+                Rdst = get_dist(RMMA,RANK)
+                Ldst = get_dist(LMMA,LANK)
                 Rwidth.append(Rdst)
                 Lwidth.append(Ldst)
 

--- a/pyCGM_Single/pycgmStatic.py
+++ b/pyCGM_Single/pycgmStatic.py
@@ -98,7 +98,10 @@ def get_dist(p0, p1):
     >>> np.around(get_dist(p0,p1), 2)
     1072.36
     """
-    distance = sqrt((p0[0] - p1[0])**2 + (p0[1] - p1[1])**2 + (p0[2] - p1[2])**2)
+    p0 = np.asarray(p0)
+    p1 = np.asarray(p1)
+
+    distance = np.linalg.norm(p0 - p1)
     return distance
 
 def getStatic(motionData,vsk,flat_foot=False,GCS=None):

--- a/pyCGM_Single/tests/test_pycgmStatic_utils.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_utils.py
@@ -13,7 +13,7 @@ class TestPycgmStaticUtils():
     """
     This class tests the utils functions in pycgmStatic.py:
     rotmat
-    getDist
+    get_dist
     getStatic
     average
     IADcalculation
@@ -100,11 +100,11 @@ class TestPycgmStaticUtils():
         result = pycgmStatic.get_dist(p0, p1)
         np.testing.assert_almost_equal(result, expected_results, rounding_precision)
 
-    def test_getDist_datatypes(self):
+    def test_get_dist_datatypes(self):
         """
-        This test provides coverage of the getDist function in pycgmStatic.py, defined as getDist(p0, p1)
+        This test provides coverage of the get_dist function in pycgmStatic.py, defined as get_dist(p0, p1)
 
-        This test checks that the resulting output from calling getDist is correct when called with a list of ints,
+        This test checks that the resulting output from calling get_dist is correct when called with a list of ints,
         a numpy array of ints, a list of floats, and a numpy array of floats.
         """
         p0_int = [7, -2, 5]
@@ -113,20 +113,20 @@ class TestPycgmStaticUtils():
         p1_float = [1.0, -4.0, 9.0]
         expected_results = 7.483314773547883
 
-        # Check that calling getDist on a list of ints yields the expected results
-        result_int_list = pycgmStatic.getDist(p0_int, p1_int)
+        # Check that calling get_dist on a list of ints yields the expected results
+        result_int_list = pycgmStatic.get_dist(p0_int, p1_int)
         np.testing.assert_almost_equal(result_int_list, expected_results, rounding_precision)
 
-        # Check that calling getDist on a numpy array of ints yields the expected results
-        result_int_nparray = pycgmStatic.getDist(np.array(p0_int, dtype='int'), np.array(p1_int, dtype='int'))
+        # Check that calling get_dist on a numpy array of ints yields the expected results
+        result_int_nparray = pycgmStatic.get_dist(np.array(p0_int, dtype='int'), np.array(p1_int, dtype='int'))
         np.testing.assert_almost_equal(result_int_nparray, expected_results, rounding_precision)
 
-        # Check that calling getDist on a list of floats yields the expected results
-        result_float_list = pycgmStatic.getDist(p0_float, p1_float)
+        # Check that calling get_dist on a list of floats yields the expected results
+        result_float_list = pycgmStatic.get_dist(p0_float, p1_float)
         np.testing.assert_almost_equal(result_float_list, expected_results, rounding_precision)
 
-        # Check that calling getDist on a numpy array of floats yields the expected results
-        result_float_nparray = pycgmStatic.getDist(np.array(p0_float, dtype='float'), np.array(p1_float, dtype='float'))
+        # Check that calling get_dist on a numpy array of floats yields the expected results
+        result_float_nparray = pycgmStatic.get_dist(np.array(p0_float, dtype='float'), np.array(p1_float, dtype='float'))
         np.testing.assert_almost_equal(result_float_nparray, expected_results, rounding_precision)
 
     @pytest.mark.parametrize(["list", "expected_results"], [

--- a/pyCGM_Single/tests/test_pycgmStatic_utils.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_utils.py
@@ -78,14 +78,14 @@ class TestPycgmStaticUtils():
         ([3, 3, 0], [3, 0, 3], 4.242640687119285),
         ([7, 0, -4], [7, 0, 2], 6),
         ([7, -2, 5], [1, -4, 9], 7.483314773547883)])
-    def test_getDist(self, p0, p1, expected_results):
+    def test_get_dist(self, p0, p1, expected_results):
         """
-        This test provides coverage of the getDist function in pycgmStatic.py, defined as getDist(p0, p1)
+        This test provides coverage of the get_dist function in pycgmStatic.py, defined as get_dist(p0, p1)
 
         This test takes 3 parameters:
-        p0: position of first x,y,z coordinate
-        p1: position of second x,y,z coordinate
-        expected_results: the expected result from calling getDist on p0 and p1. This will be the distance between p0 and p1
+        p0: position of first (x, y, z) coordinate
+        p1: position of second (x, y, z) coordinate
+        expected_results: the expected result from calling get_dist on p0 and p1. This will be the distance between p0 and p1
 
         Given the points p0 and p1, the distance between them is defined as:
         .. math::
@@ -97,7 +97,7 @@ class TestPycgmStaticUtils():
         coordinates are different
         - the distance is measured correctly given positive, negative and zero values
         """
-        result = pycgmStatic.getDist(p0, p1)
+        result = pycgmStatic.get_dist(p0, p1)
         np.testing.assert_almost_equal(result, expected_results, rounding_precision)
 
     def test_getDist_datatypes(self):


### PR DESCRIPTION
### Summary of PR:
Modify getDist to use `np.linalg.norm`. Update getStatic function call.

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- pycgmStatic.py - Refactor function, getStatic function call change
- test_pycgmStatic_utils.py - Fix get_dist test docstrings

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [x] Change/Remove tests
- [ ] Add code
- [x] Change/Remove code
- [x] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
All get_dist tests passing

### Docstring: get_dist
![static_get_dist](https://user-images.githubusercontent.com/50923525/132406207-15e289a1-4f52-4c89-949c-eb6e56d86bf8.png)



