### PR TITLE
Clean up static average 

### DIFF
--- a/pyCGM_Single/pycgmStatic.py
+++ b/pyCGM_Single/pycgmStatic.py
@@ -274,38 +274,34 @@ def getStatic(motionData,vsk,flat_foot=False,GCS=None):
 
     return calSM
 
-def average(list):
+def average(lst):
     """Average Calculation function
 
-    Calculates the average of the values in a given list or array.
+    Calculates the average of the values in a given lst or array.
 
     Parameters
     ----------
-    list : list
+    lst : list
         List or array of values.
 
     Returns
     -------
-    float
+    avg : float
         The mean of the list.
 
     Examples
     --------
     >>> import numpy as np
     >>> from .pycgmStatic import average
-    >>> list = [1,2,3,4,5]
-    >>> average(list)
+    >>> lst = [1,2,3,4,5]
+    >>> average(lst)
     3.0
-    >>> list = np.array([93.82, 248.96, 782.62])
-    >>> np.around(average(list), 2)
+    >>> lst = np.array([93.82, 248.96, 782.62])
+    >>> np.around(average(lst), 2)
     375.13
     """
-    i =0
-    total = 0.0
-    while(i <len(list)):
-        total = total + list[i]
-        i = i+1
-    return total / len(list)
+    avg = sum(lst) / len(lst)
+    return avg
 
 def IADcalculation(frame):
     """Inter ASIS Distance (IAD) Calculation function

--- a/pyCGM_Single/tests/test_pycgmStatic_utils.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_utils.py
@@ -129,7 +129,7 @@ class TestPycgmStaticUtils():
         result_float_nparray = pycgmStatic.getDist(np.array(p0_float, dtype='float'), np.array(p1_float, dtype='float'))
         np.testing.assert_almost_equal(result_float_nparray, expected_results, rounding_precision)
 
-    @pytest.mark.parametrize(["list", "expected_results"], [
+    @pytest.mark.parametrize(["lst", "expected_results"], [
         ([0], 0),
         ([3], 3),
         ([-1], -1),
@@ -140,15 +140,15 @@ class TestPycgmStaticUtils():
         ([1, 2, 3, 4, 5], 3),
         ([-1, -2, -3, -4, -5], -3),
         ([0.1, 0.2, 0.3, 0.4, 0.5], 0.3)])
-    def test_average(self, list, expected_results):
+    def test_average(self, lst, expected_results):
         """
-        This test provides coverage of the average function in pycgmStatic.py, defined as average(list)
+        This test provides coverage of the average function in pycgmStatic.py, defined as average(lst)
 
         This test takes 2 parameters:
-        list: list or array of values
-        expected_results: the expected result from calling average on list. This will be the average of all the values given in list
+        lst: list or array of values
+        expected_results: the expected result from calling average on lst. This will be the average of all the values given in lst.
         """
-        result = pycgmStatic.average(list)
+        result = pycgmStatic.average(lst)
         np.testing.assert_almost_equal(result, expected_results, rounding_precision)
 
     def test_average_datatypes(self):


### PR DESCRIPTION
### Summary of PR:
Clean up static average function, avoid using built-in type `list`

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- pycgmStatic.py - Replace function, update docstring
- test_pycgmStatic_utils.py - Fix average test docstring and variable name

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [ ] Change/Remove tests
- [ ] Add code
- [x] Change/Remove code
- [x] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
All average tests passing

### Docstring: average
![static_average](https://user-images.githubusercontent.com/50923525/132406677-19a36375-bd9d-4e90-b232-b279cd36ed93.png)


