### PR TITLE
Refactor static staticCalculationHead and headOffCalc

### DIFF
--- a/pyCGM_Single/pycgmStatic.py
+++ b/pyCGM_Single/pycgmStatic.py
@@ -256,7 +256,10 @@ def getStatic(motionData,vsk,flat_foot=False,GCS=None):
         knee_JC = kneeJointCenter(frame,hip_JC,0,vsk=calSM)
         ankle_JC = ankleJointCenter(frame,knee_JC,0,vsk=calSM)
         angle = staticCalculation(frame,ankle_JC,knee_JC,flat_foot,calSM)
-        head = headJC(frame)
+        head = calc_axis_head(frame['LFHD'] if 'LFHD' in frame else None,
+                              frame['RFHD'] if 'RFHD' in frame else None,
+                              frame['LBHD'] if 'LBHD' in frame else None,
+                              frame['RBHD'] if 'RBHD' in frame else None)
         headangle = staticCalculationHead(frame,head)
 
         static_offset.append(angle)
@@ -1444,86 +1447,96 @@ def footJointCenter(frame,static_info,ankle_JC,knee_JC,delta):
 
     return [R,L,foot_axis]
 
-def headJC(frame):
-    """Calculate the head joint axis function.
+def calc_axis_head(lfhd, rfhd, lbhd, rbhd):
+    """Calculate the head joint center and axis.
 
-    Takes in a dictionary of x,y,z positions and marker names.
-    Calculates the head joint center and returns the head joint center and axis.
+    Takes in markers that correspond to (x, y, z) positions of the current
+    frame, and the head offset. 
+
+    Calculates the head joint center and axis.
 
     Markers used: LFHD, RFHD, LBHD, RBHD
 
     Parameters
     ----------
-    frame : dict
-        Dictionary of marker lists.
+    lfhd : array
+        1x3 LFHD marker
+    rfhd : array
+        1x3 RFHD marker
+    lbhd : array
+        1x3 LBHD marker
+    rbhd : array
+        1x3 RBHD marker
 
     Returns
     -------
-    head_axis, origin : list
-        Returns a list containing a 1x3x3 list containing the x, y, z axis
-        components of the head joint center and a 1x3 list containing the
-        head origin x, y, z position.
+    head_axis : array
+        4x4 affine matrix with head (x, y, z) axes and origin.
+
 
     Examples
     --------
     >>> import numpy as np
-    >>> from .pycgmStatic import headJC
-    >>> frame = {'RFHD': np.array([325.83, 402.55, 1722.5]),
-    ...          'LFHD': np.array([184.55, 409.69, 1721.34]),
-    ...          'RBHD': np.array([304.4, 242.91, 1694.97]),
-    ...          'LBHD': np.array([197.86, 251.29, 1696.90])}
-    >>> [np.around(arr, 2) for arr in headJC(frame)] #doctest: +NORMALIZE_WHITESPACE
-    [array([[ 255.22,  407.11, 1722.08],
-            [ 254.19,  406.15, 1721.92],
-            [ 255.18,  405.96, 1722.91]]), array([ 255.19,  406.12, 1721.92])]
+    >>> np.set_printoptions(suppress=True)
+    >>> from .pycgmStatic import calc_axis_head
+    >>> rfhd = np.array([325.82, 402.55, 1722.49])
+    >>> lfhd = np.array([184.55, 409.68, 1721.34])
+    >>> rbhd = np.array([304.39, 242.91, 1694.97])
+    >>> lbhd = np.array([197.86, 251.28, 1696.90])
+    >>> [np.around(arr, 2) for arr in calc_axis_head(lfhd, rfhd, lbhd, rbhd)] #doctest: +NORMALIZE_WHITESPACE
+    [array([  0.03,   0.99,  0.16,  255.18]),
+     array([ -1.  ,   0.03, -0.  ,  406.12]),
+     array([ -0.01,  -0.16,  0.99, 1721.92]),
+       array([0.,     0.,    0.,      1.])]
     """
 
-    #Get the marker positions used for joint calculation
-    LFHD = frame['LFHD']
-    RFHD = frame['RFHD']
-    LBHD = frame['LBHD']
-    RBHD = frame['RBHD']
+    lfhd, rfhd, lbhd, rbhd = map(np.array, [lfhd, rfhd, lbhd, rbhd])
 
-    #get the midpoints of the head to define the sides
-    front = [(LFHD[0]+RFHD[0])/2.0, (LFHD[1]+RFHD[1])/2.0,(LFHD[2]+RFHD[2])/2.0]
-    back = [(LBHD[0]+RBHD[0])/2.0, (LBHD[1]+RBHD[1])/2.0,(LBHD[2]+RBHD[2])/2.0]
-    left = [(LFHD[0]+LBHD[0])/2.0, (LFHD[1]+LBHD[1])/2.0,(LFHD[2]+LBHD[2])/2.0]
-    right = [(RFHD[0]+RBHD[0])/2.0, (RFHD[1]+RBHD[1])/2.0,(RFHD[2]+RBHD[2])/2.0]
-    origin = front
+    # get the midpoints of the head to define the sides
+    front = (lfhd + rfhd) / 2.0
+    back  = (lbhd + rbhd) / 2.0
+    left  = (lfhd + lbhd) / 2.0
+    right = (rfhd + rbhd) / 2.0
 
-    #Get the vectors from the sides with primary x axis facing front
-    #First get the x direction
-    x_vec = [front[0]-back[0],front[1]-back[1],front[2]-back[2]]
-    x_vec_div = norm2d(x_vec)
-    x_vec = [x_vec[0]/x_vec_div,x_vec[1]/x_vec_div,x_vec[2]/x_vec_div]
+    # Get the vectors from the sides with primary x axis facing front
+    # First get the x direction
+    x_axis = np.subtract(front, back)
+    x_axis_norm = np.nan_to_num(np.linalg.norm(x_axis))
+    if x_axis_norm:
+        x_axis = np.divide(x_axis, x_axis_norm)
 
-    #get the direction of the y axis
-    y_vec = [left[0]-right[0],left[1]-right[1],left[2]-right[2]]
-    y_vec_div = norm2d(y_vec)
-    y_vec = [y_vec[0]/y_vec_div,y_vec[1]/y_vec_div,y_vec[2]/y_vec_div]
+    # get the direction of the y axis
+    y_axis = np.subtract(left, right)
+    y_axis_norm = np.nan_to_num(np.linalg.norm(y_axis))
+    if y_axis_norm:
+        y_axis = np.divide(y_axis, y_axis_norm)
 
     # get z axis by cross-product of x axis and y axis.
-    z_vec = cross(x_vec,y_vec)
-    z_vec_div = norm2d(z_vec)
-    z_vec = [z_vec[0]/z_vec_div,z_vec[1]/z_vec_div,z_vec[2]/z_vec_div]
+    z_axis = np.cross(x_axis, y_axis)
+    z_axis_norm = np.nan_to_num(np.linalg.norm(z_axis))
+    if z_axis_norm:
+        z_axis = np.divide(z_axis, z_axis_norm)
 
     # make sure all x,y,z axis is orthogonal each other by cross-product
-    y_vec = cross(z_vec,x_vec)
-    y_vec_div = norm2d(y_vec)
-    y_vec = [y_vec[0]/y_vec_div,y_vec[1]/y_vec_div,y_vec[2]/y_vec_div]
-    x_vec = cross(y_vec,z_vec)
-    x_vec_div = norm2d(x_vec)
-    x_vec = [x_vec[0]/x_vec_div,x_vec[1]/x_vec_div,x_vec[2]/x_vec_div]
+    y_axis = np.cross(z_axis, x_axis)
+    y_axis_norm = np.nan_to_num(np.linalg.norm(y_axis))
+    if y_axis_norm:
+        y_axis = np.divide(y_axis, y_axis_norm)
 
-    #Add the origin back to the vector to get it in the right position
-    x_axis = [x_vec[0]+origin[0],x_vec[1]+origin[1],x_vec[2]+origin[2]]
-    y_axis = [y_vec[0]+origin[0],y_vec[1]+origin[1],y_vec[2]+origin[2]]
-    z_axis = [z_vec[0]+origin[0],z_vec[1]+origin[1],z_vec[2]+origin[2]]
+    x_axis = np.cross(y_axis, z_axis)
+    x_axis_norm = np.nan_to_num(np.linalg.norm(x_axis))
+    if x_axis_norm:
+        x_axis = np.divide(x_axis, x_axis_norm)
 
-    head_axis =[x_axis,y_axis,z_axis]
+    # Create the return matrix
+    head_axis = np.zeros((4, 4))
+    head_axis[3, 3] = 1.0
+    head_axis[0, :3] = x_axis
+    head_axis[1, :3] = y_axis
+    head_axis[2, :3] = z_axis
+    head_axis[:3, 3] = front
 
-    #Return the three axis and origin
-    return [head_axis,origin]
+    return head_axis
 
 def uncorrect_footaxis(frame,ankle_JC):
     """Calculate the anatomically uncorrected foot joint center and axis function.

--- a/pyCGM_Single/tests/test_pycgmStatic_axis.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_axis.py
@@ -892,72 +892,228 @@ class TestPycgmStaticAxis():
         np.testing.assert_almost_equal(result[1], expected[1], rounding_precision)
         np.testing.assert_almost_equal(result[2], expected[2], rounding_precision)
 
-    @pytest.mark.parametrize(["frame", "expected"], [
-        # Test from running sample data
-        ({'LFHD': np.array([184.55158997, 409.68713379, 1721.34289551]), 'RFHD': np.array([325.82983398, 402.55450439, 1722.49816895]), 'LBHD': np.array([197.8621521 , 251.28889465, 1696.90197754]), 'RBHD': np.array([304.39898682, 242.91339111, 1694.97497559])},
-         [[[255.21590218, 407.10741939, 1722.0817318], [254.19105385, 406.14680918, 1721.91767712], [255.18370553, 405.95974655, 1722.90744993]], [255.19071197509766, 406.1208190917969, 1721.9205322265625]]),
-        # Basic test with a variance of 1 in the x and y dimensions of the markers
-        ({'LFHD': np.array([1, 1, 0]), 'RFHD': np.array([0, 1, 0]), 'LBHD': np.array([1, 0, 0]), 'RBHD': np.array([0, 0, 0])},
-         [[[0.5, 2, 0], [1.5, 1, 0], [0.5, 1, -1]], [0.5, 1, 0]]),
-        # Setting the markers so there's no variance in the x-dimension
-        ({'LFHD': np.array([0, 1, 0]), 'RFHD': np.array([0, 1, 0]), 'LBHD': np.array([0, 0, 0]), 'RBHD': np.array([0, 0, 0])},
-         [[nan_3d, nan_3d, nan_3d], [0, 1, 0]]),
-        # Setting the markers so there's no variance in the y-dimension
-        ({'LFHD': np.array([1, 0, 0]), 'RFHD': np.array([0, 0, 0]), 'LBHD': np.array([1, 0, 0]), 'RBHD': np.array([0, 0, 0])},
-         [[nan_3d, nan_3d, nan_3d], [0.5, 0, 0]]),
-        # Setting each marker in a different xy quadrant
-        ({'LFHD': np.array([-1, 1, 0]), 'RFHD': np.array([1, 1, 0]), 'LBHD': np.array([-1, -1, 0]), 'RBHD': np.array([1, -1, 0])},
-         [[[0, 2, 0], [-1, 1, 0], [0, 1, 1]], [0, 1, 0]]),
-        # Setting values of the markers so that midpoints will be on diagonals
-        ({'LFHD': np.array([-2, 1, 0]), 'RFHD': np.array([1, 2, 0]), 'LBHD': np.array([-1, -2, 0]), 'RBHD': np.array([2, -1, 0])},
-         [[[-0.81622777, 2.4486833 ,  0], [-1.4486833, 1.18377223, 0], [-0.5, 1.5,  1]], [-0.5, 1.5, 0]]),
-        # Adding the value of 1 in the z dimension for all 4 markers
-        ({'LFHD': np.array([1, 1, 1]), 'RFHD': np.array([0, 1, 1]), 'LBHD': np.array([1, 0, 1]), 'RBHD': np.array([0, 0, 1])},
-         [[[0.5, 2, 1], [1.5, 1, 1], [0.5, 1, 0]], [0.5, 1, 1]]),
-        # Setting the z dimension value higher for LFHD and LBHD
-        ({'LFHD': np.array([1, 1, 2]), 'RFHD': np.array([0, 1, 1]), 'LBHD': np.array([1, 0, 2]), 'RBHD': np.array([0, 0, 1])},
-         [[[0.5, 2, 1.5], [1.20710678, 1, 2.20710678], [1.20710678, 1, 0.79289322]], [0.5, 1, 1.5]]),
-        # Setting the z dimension value higher for LFHD and RFHD
-        ({'LFHD': np.array([1, 1, 2]), 'RFHD': np.array([0, 1, 2]), 'LBHD': np.array([1, 0, 1]), 'RBHD': np.array([0, 0, 1])},
-         [[[0.5, 1.70710678, 2.70710678], [1.5, 1, 2], [0.5, 1.70710678, 1.29289322]], [0.5, 1, 2]]),
+    @pytest.mark.parametrize(
+        ["frame", "expected"],
+        [
+            # Test from running sample data
+            (
+                {
+                    "LFHD": np.array([184.55158997, 409.68713379, 1721.34289551]),
+                    "RFHD": np.array([325.82983398, 402.55450439, 1722.49816895]),
+                    "LBHD": np.array([197.8621521, 251.28889465, 1696.90197754]),
+                    "RBHD": np.array([304.39898682, 242.91339111, 1694.97497559]),
+                },
+                np.array([[255.21590218, 407.10741939, 1722.0817318,   255.19071197509766],
+                          [254.19105385, 406.14680918, 1721.91767712,  406.1208190917969 ],
+                          [255.18370553, 405.95974655, 1722.90744993, 1721.9205322265625 ],
+                          [  0,            0,             0,             1               ]]
+                        )
+            ),
+            # Basic test with a variance of 1 in the x and y dimensions of the markers
+            (
+                {
+                    "LFHD": np.array([1, 1, 0]),
+                    "RFHD": np.array([0, 1, 0]),
+                    "LBHD": np.array([1, 0, 0]),
+                    "RBHD": np.array([0, 0, 0]),
+                },
+                np.array([[0.5, 2,  0, 0.5],
+                          [1.5, 1,  0, 1  ],
+                          [0.5, 1, -1, 0  ],
+                          [0,   0,  0, 1  ]])
 
-        # Testing that when frame is composed of lists of ints
-        ({'LFHD': [1, 1, 2], 'RFHD': [0, 1, 2], 'LBHD': [1, 0, 1], 'RBHD': [0, 0, 1]},
-         [[[0.5, 1.70710678, 2.70710678], [1.5, 1, 2], [0.5, 1.70710678, 1.29289322]], [0.5, 1, 2]]),
-        # Testing that when frame is composed of numpy arrays of ints
-        ({'LFHD': np.array([1, 1, 2], dtype='int'), 'RFHD': np.array([0, 1, 2], dtype='int'),
-          'LBHD': np.array([1, 0, 1], dtype='int'), 'RBHD': np.array([0, 0, 1], dtype='int')},
-         [[[0.5, 1.70710678, 2.70710678], [1.5, 1, 2], [0.5, 1.70710678, 1.29289322]], [0.5, 1, 2]]),
-        # Testing that when frame is composed of lists of floats
-        ({'LFHD': [1.0, 1.0, 2.0], 'RFHD': [0.0, 1.0, 2.0], 'LBHD': [1.0, 0.0, 1.0], 'RBHD': [0.0, 0.0, 1.0]},
-         [[[0.5, 1.70710678, 2.70710678], [1.5, 1, 2], [0.5, 1.70710678, 1.29289322]], [0.5, 1, 2]]),
-        # Testing that when frame is composed of numpy arrays of floats
-        ({'LFHD': np.array([1.0, 1.0, 2.0], dtype='float'), 'RFHD': np.array([0.0, 1.0, 2.0], dtype='float'),
-          'LBHD': np.array([1.0, 0.0, 1.0], dtype='float'), 'RBHD': np.array([0.0, 0.0, 1.0], dtype='float')},
-         [[[0.5, 1.70710678, 2.70710678], [1.5, 1, 2], [0.5, 1.70710678, 1.29289322]], [0.5, 1, 2]])])
-    def test_headJC(self, frame, expected):
+            ),
+            # Setting the markers so there's no variance in the x-dimension
+            (
+                {
+                    "LFHD": np.array([0, 1, 0]),
+                    "RFHD": np.array([0, 1, 0]),
+                    "LBHD": np.array([0, 0, 0]),
+                    "RBHD": np.array([0, 0, 0]),
+                },
+                np.array([[0, 1, 0, 0],
+                          [0, 1, 0, 1],
+                          [0, 1, 0, 0],
+                          [0, 0, 0, 1]]
+                        )
+            ),
+            # Setting the markers so there's no variance in the y-dimension
+            (
+                {
+                    "LFHD": np.array([1, 0, 0]),
+                    "RFHD": np.array([0, 0, 0]),
+                    "LBHD": np.array([1, 0, 0]),
+                    "RBHD": np.array([0, 0, 0]),
+                },
+                np.array([[0.5, 0, 0, 0.5],
+                          [0.5, 0, 0, 0  ],
+                          [0.5, 0, 0, 0  ],
+                          [0,   0, 0, 1  ]]
+                        )
+            ),
+            # Setting each marker in a different xy quadrant
+            (
+                {
+                    "LFHD": np.array([-1, 1, 0]),
+                    "RFHD": np.array([1, 1, 0]),
+                    "LBHD": np.array([-1, -1, 0]),
+                    "RBHD": np.array([1, -1, 0]),
+                },
+                np.array([[ 0, 2, 0, 0],
+                          [-1, 1, 0, 1],
+                          [ 0, 1, 1, 0],
+                          [ 0, 0, 0, 1]]
+                        )
+            ),
+            # Setting values of the markers so that midpoints will be on diagonals
+            (
+                {
+                    "LFHD": np.array([-2, 1, 0]),
+                    "RFHD": np.array([1, 2, 0]),
+                    "LBHD": np.array([-1, -2, 0]),
+                    "RBHD": np.array([2, -1, 0]),
+                },
+                np.array([[-0.81622777, 2.4486833,  0, -0.5],
+                          [-1.4486833,  1.18377223, 0,  1.5],
+                          [-0.5,        1.5,        1,  0  ],
+                          [ 0,          0,          0,  1  ]]
+                        )
+            ),
+            # Adding the value of 1 in the z dimension for all 4 markers
+            (
+                {
+                    "LFHD": np.array([1, 1, 1]),
+                    "RFHD": np.array([0, 1, 1]),
+                    "LBHD": np.array([1, 0, 1]),
+                    "RBHD": np.array([0, 0, 1]),
+                },
+                np.array([[0.5, 2, 1, 0.5],
+                          [1.5, 1, 1, 1  ],
+                          [0.5, 1, 0, 1  ],
+                          [0,   0, 0, 1  ]])
+            ),
+            # Setting the z dimension value higher for LFHD and LBHD
+            (
+                {
+                    "LFHD": np.array([1, 1, 2]),
+                    "RFHD": np.array([0, 1, 1]),
+                    "LBHD": np.array([1, 0, 2]),
+                    "RBHD": np.array([0, 0, 1]),
+                },
+                np.array([[0.5,        2, 1.5,        0.5],
+                          [1.20710678, 1, 2.20710678, 1  ],
+                          [1.20710678, 1, 0.79289322, 1.5],
+                          [0,          0, 0,          1 ]]
+                        )
+            ),
+            # Setting the z dimension value higher for LFHD and RFHD
+            (
+                {
+                    "LFHD": np.array([1, 1, 2]),
+                    "RFHD": np.array([0, 1, 2]),
+                    "LBHD": np.array([1, 0, 1]),
+                    "RBHD": np.array([0, 0, 1]),
+                },
+                np.array([[0.5, 1.70710678, 2.70710678, 0.5],
+                          [1.5, 1,          2,          1  ],
+                          [0.5, 1.70710678, 1.29289322, 2  ],
+                          [0,   0,          0,          1  ]]
+                        )
+            ),
+            # Testing that when frame is composed of lists of ints
+            (
+                {
+                    "LFHD": [1, 1, 2],
+                    "RFHD": [0, 1, 2],
+                    "LBHD": [1, 0, 1],
+                    "RBHD": [0, 0, 1],
+                },
+                np.array([[0.5, 1.70710678, 2.70710678, 0.5],
+                          [1.5, 1,          2,          1  ],
+                          [0.5, 1.70710678, 1.29289322, 2  ],
+                          [0,   0,          0,          1  ]]
+                        )
+            ),
+            # Testing that when frame is composed of numpy arrays of ints
+            (
+                {
+                    "LFHD": np.array([1, 1, 2], dtype="int"),
+                    "RFHD": np.array([0, 1, 2], dtype="int"),
+                    "LBHD": np.array([1, 0, 1], dtype="int"),
+                    "RBHD": np.array([0, 0, 1], dtype="int"),
+                },
+                np.array([[0.5, 1.70710678, 2.70710678, 0.5],
+                          [1.5, 1,          2,          1  ],
+                          [0.5, 1.70710678, 1.29289322, 2  ],
+                          [0,   0,          0,          1  ]]
+                        )
+            ),
+            # Testing that when frame is composed of lists of floats
+            (
+                {
+                    "LFHD": [1.0, 1.0, 2.0],
+                    "RFHD": [0.0, 1.0, 2.0],
+                    "LBHD": [1.0, 0.0, 1.0],
+                    "RBHD": [0.0, 0.0, 1.0],
+                },
+                np.array([[0.5, 1.70710678, 2.70710678, 0.5],
+                          [1.5, 1,          2,          1  ],
+                          [0.5, 1.70710678, 1.29289322, 2  ],
+                          [0,   0,          0,          1  ]]
+                        )
+            ),
+            # Testing that when frame is composed of numpy arrays of floats
+            (
+                {
+                    "LFHD": np.array([1.0, 1.0, 2.0], dtype="float"),
+                    "RFHD": np.array([0.0, 1.0, 2.0], dtype="float"),
+                    "LBHD": np.array([1.0, 0.0, 1.0], dtype="float"),
+                    "RBHD": np.array([0.0, 0.0, 1.0], dtype="float"),
+                },
+                np.array([[0.5, 1.70710678, 2.70710678, 0.5],
+                          [1.5, 1,          2,          1  ],
+                          [0.5, 1.70710678, 1.29289322, 2  ],
+                          [0,   0,          0,          1  ]]
+                        )
+            ),
+        ],
+    )
+    def test_calc_axis_head(self, frame, expected):
         """
-        This test provides coverage of the headJC function in pycgmStatic.py, defined as headJC(frame)
+        This test provides coverage of the calc_axis_head function in pycgmStatic.py, defined as 
+        calc_axis_head(lfhd, rfhd, lbhd, rbhd)
+
         This test takes 3 parameters:
         frame: dictionary of marker lists
-        expected: the expected result from calling headJC on frame
+        expected: the expected result from calling calc_axis_head on lfhd, rfhd, lbhd and rbhd
 
         This test is checking to make sure the head joint center and head joint axis are calculated correctly given
         the 4 coordinates given in frame. This includes testing when there is no variance in the coordinates,
         when the coordinates are in different quadrants, when the midpoints will be on diagonals, and when the z
-        dimension is variable. It also checks to see the difference when a value is set for HeadOffSet in vsk.
+        dimension is variable.
 
-        The function uses the LFHD, RFHD, LBHD, and RBHD markers from the frame to calculate the midpoints of the front, back, left, and right center positions of the head. 
+        The function uses the LFHD, RFHD, LBHD, and RBHD markers from the frame to calculate the midpoints of the 
+        front, back, left, and right center positions of the head. 
         The head axis vector components are then calculated using the aforementioned midpoints.
-        Afterwords, the axes are made orthogonal by calculating the cross product of each individual axis. 
-        Finally, the head axis is then rotated around the y axis based off the head offset angle in the VSK. 
+        Finally, the axes are made orthogonal by calculating the cross product of each individual axis. 
 
         Lastly, it checks that the resulting output is correct when frame composed of lists of ints, numpy arrays of
-        ints, lists of floats, and numpy arrays of floats and when headOffset is an int and a float.
+        ints, lists of floats, and numpy arrays of floats.
         """
-        result = pycgmStatic.headJC(frame)
-        np.testing.assert_almost_equal(result[0], expected[0], rounding_precision)
-        np.testing.assert_almost_equal(result[1], expected[1], rounding_precision)
+        lfhd = frame["LFHD"] if "LFHD" in frame else None
+        rfhd = frame["RFHD"] if "RFHD" in frame else None
+        lbhd = frame["LBHD"] if "LBHD" in frame else None
+        rbhd = frame["RBHD"] if "RBHD" in frame else None
+
+        result = pycgmStatic.calc_axis_head(lfhd, rfhd, lbhd, rbhd)
+
+        result_o = result[:3, 3]
+        result[0, :3] += result_o
+        result[1, :3] += result_o
+        result[2, :3] += result_o
+
+        np.testing.assert_almost_equal(result, expected, rounding_precision)
+
 
     @pytest.mark.parametrize(["frame", "ankle_JC", "expected"], [
         # Test from running sample data

--- a/pyCGM_Single/tests/test_pycgmStatic_axis.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_axis.py
@@ -3,12 +3,12 @@ import pyCGM_Single.pycgmStatic as pycgmStatic
 import numpy as np
 from mock import patch
 
-rounding_precision = 8
+rounding_precision = 5
 
 class TestPycgmStaticAxis():
     """
     This class tests the axis functions in pycgmStatic.py:
-        staticCalculationHead
+        calc_static_head
         pelvisJointCenter
         hipJointCenter
         hipAxisCenter

--- a/pyCGM_Single/tests/test_pycgmStatic_axis.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_axis.py
@@ -24,63 +24,141 @@ class TestPycgmStaticAxis():
     nan_3d = [np.nan, np.nan, np.nan]
     rand_coor = [np.random.randint(0, 10), np.random.randint(0, 10), np.random.randint(0, 10)]
 
-    @pytest.mark.parametrize(["head", "expected"], [
-        # Test from running sample data
-        ([[[244.87227957886893, 326.0240255639856, 1730.4189843948805],
-           [243.89575702706503, 325.0366593474616, 1730.1515677531293],
-           [244.89086730509763, 324.80072493605866, 1731.1283433097797]],
-          [244.89547729492188, 325.0578918457031, 1730.1619873046875]],
-         0.25992807335420975),
-        # Test with zeros for all params
-        ([[[0, 0, 0], [0, 0, 0], [0, 0, 0]], [0, 0, 0]],
-         np.nan),
-        # Testing when values are added to head[0][0]
-        ([[[-1, 8, 9], [0, 0, 0], [0, 0, 0]], [0, 0, 0]],
-         1.5707963267948966),
-        # Testing when values are added to head[0][1]
-        ([[[0, 0, 0], [7, 5, 7], [0, 0, 0]], [0, 0, 0]],
-         np.nan),
-        # Testing when values are added to head[0][2]
-        ([[[0, 0, 0], [0, 0, 0], [3, -6, -2]], [0, 0, 0]],
-         0.0),
-        # Testing when values are added to head[0]
-        ([[[-1, 8, 9], [7, 5, 7], [3, -6, -2]], [0, 0, 0]],
-         -1.3521273809209546),
-        # Testing when values are added to head[1]
-        ([[[0, 0, 0], [0, 0, 0], [0, 0, 0]], [-4, 7, 8]],
-         0.7853981633974483),
-        # Testing when values are added to head
-        ([[[-1, 8, 9], [7, 5, 7], [3, -6, -2]], [-4, 7, 8]],
-         -0.09966865249116204),
-        # Testing that when head is composed of lists of ints
-        ([[[-1, 8, 9], [7, 5, 7], [3, -6, -2]], [-4, 7, 8]],
-         -0.09966865249116204),
-        # Testing that when head is composed of numpy arrays of ints
-        ([np.array([[-1, 8, 9], [7, 5, 7], [3, -6, -2]], dtype='int'), np.array([-4, 7, 8], dtype='int')],
-         -0.09966865249116204),
-        # Testing that when head is composed of lists of floats
-        ([[[-1.0, 8.0, 9.0], [7.0, 5.0, 7.0], [3.0, -6.0, -2.0]], [-4.0, 7.0, 8.0]],
-         -0.09966865249116204),
-        # Testing that when head is composed of numpy arrays of floats
-        ([np.array([[-1.0, 8.0, 9.0], [7.0, 5.0, 7.0], [3.0, -6.0, -2.0]], dtype='float'), np.array([-4.0, 7.0, 8.0], dtype='float')],
-         -0.09966865249116204)])
-    def test_staticCalculationHead(self, head, expected):
+    @pytest.mark.parametrize(
+        ["head_axis", "expected"],
+        [
+            # Test from running sample data
+            (
+                np.array([[244.87227957886893, 326.0240255639856, 1730.4189843948805, 244.89547729492188],
+                          [243.89575702706503, 325.0366593474616, 1730.1515677531293, 325.0578918457031],
+                          [244.89086730509763, 324.80072493605866, 1731.1283433097797, 1730.1619873046875],
+                          [0, 0, 0, 0]]),
+                0.25992807335420975,
+            ),
+            # Test with zeros for all params
+            (
+                np.array([[0, 0, 0, 0],
+                          [0, 0, 0, 0],
+                          [0, 0, 0, 0],
+                          [0, 0, 0, 1]]
+                        ),
+                np.nan
+            ),
+            # Testing when values are added to head x-axis
+            (
+                np.array([[-1, 8, 9, 0],
+                          [ 0, 0, 0, 0],
+                          [ 0, 0, 0, 0],
+                          [ 0, 0, 0, 1]]
+                        ),
+                1.5707963267948966
+            ),
+            # Testing when values are added to head y-axis
+            (
+                np.array([[0, 0, 0, 0],
+                          [7, 5, 7, 0],
+                          [0, 0, 0, 0],
+                          [0, 0, 0, 1]]
+                        ),
+                np.nan
+            ),
+            # Testing when values are added to head z-axis
+            (
+                np.array([[0,  0,  0, 0],
+                          [0,  0,  0, 0],
+                          [0, -6, -2, 0],
+                          [0,  0,  0, 1]]
+                        ),
+                0.0
+            ),
+            # Testing when values are added to head axes
+            (
+                np.array([[-1,  8,  9, 0],
+                          [7,  5,  7, 0],
+                          [0, -6, -2, 0],
+                          [0,  0,  0, 1]]
+                        ),
+                -1.3521273809209546
+            ),
+            # Testing when values are added to head origin
+            (
+                np.array([[0, 0, 0, -4],
+                          [0, 0, 0,  7],
+                          [0, 0, 0,  8],
+                          [0, 0, 0,  1]]
+                        ),
+                0.7853981633974483
+            ),
+            # Testing when values are added to head axes and origin
+            (
+                np.array([[-1,  8,  9, -4],
+                          [ 7,  5,  7,  7],
+                          [ 0, -6, -2,  8],
+                          [ 0,  0,  0,  1]]
+                        ),
+                -0.09966865249116204
+            ),
+            # Testing that when head_axis is composed of lists of ints
+            (
+                [
+                          [-1,  8,  9, -4],
+                          [ 7,  5,  7,  7],
+                          [ 3, -6, -2,  8],
+                          [ 0,  0,  0,  1]
+                ],
+                -0.09966865249116204
+            ),
+            # Testing that when head_axis is composed of numpy arrays of ints
+            (
+                np.array([[-1,  8,  9, -4],
+                          [ 7,  5,  7,  7],
+                          [ 0, -6, -2,  8],
+                          [ 0,  0,  0,  1]], dtype="int"),
+                -0.09966865249116204,
+            ),
+            # Testing that when head_axis is composed of lists of floats
+            (
+                [
+                          [-1.0,  8.0,  9.0, -4.0],
+                          [ 7.0,  5.0,  7.0,  7.0],
+                          [ 3.0, -6.0, -2.0,  8.0],
+                          [ 0.0,  0.0,  0.0,  1.0]
+                ],
+                -0.09966865249116204
+            ),
+            # Testing that when head_axis is composed of numpy arrays of floats
+            (
+                np.array([[-1.0,  8.0,  9.0, -4.0],
+                          [ 7.0,  5.0,  7.0,  7.0],
+                          [ 3.0, -6.0, -2.0,  8.0],
+                          [ 0.0,  0.0,  0.0,  1.0]], dtype="float"),
+                -0.09966865249116204
+            ),
+        ],
+    )
+    def test_calc_static_head(self, head_axis, expected):
         """
-        This test provides coverage of the staticCalculationHead function in pycgmStatic.py, defined as staticCalculationHead(frame, head)
+        This test provides coverage of the calc_static_head function in pycgmStatic.py, defined as calc_static_head(head_axis)
 
         This test takes 2 parameters:
-        head: array containing the head axis and head origin
-        expected: the expected result from calling staticCalculationHead on head
+        head_axis: 4x4 affine matrix representing the head axes and origin
+        expected: the expected result from calling calc_static_head on head_axis
 
-        This function first calculates the x, y, z axes of the head by subtracting the given head axes by the head
-        origin. It then calls headoffCalc on this head axis and a global axis to find the head offset angles.
+        This function first calculates the (x, y, z) axes of the head by subtracting the given head axes by the head
+        origin. It then calls calc_head_offset on this head axis and a global axis to find the head offset angles.
 
         This test ensures that:
         - the head axis and the head origin both have an effect on the final offset angle
-        - the resulting output is correct when head is composed of lists of ints, numpy arrays of ints, lists of
+        - the resulting output is correct when head_axis is composed of lists of ints, numpy arrays of ints, lists of
         floats, and numpy arrays of floats.
-       """
-        result = pycgmStatic.staticCalculationHead(None, head)
+        """
+        head_axis = np.asarray(head_axis)
+        head_o = head_axis[:3, 3]
+        head_axis[0, :3] -= head_o
+        head_axis[1, :3] -= head_o
+        head_axis[2, :3] -= head_o
+        
+        result = pycgmStatic.calc_static_head(head_axis)
         np.testing.assert_almost_equal(result, expected, rounding_precision)
 
     @pytest.mark.parametrize(["frame", "expected"], [


### PR DESCRIPTION
### Summary of PR:
Refactor static staticCalculationHead and headOffCalc. Update getStatic function call.

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- pycgmStatic.py - Refactor functions
- test_pycgmStatic_axis.py - Refactor test

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [x] Change/Remove tests
- [ ] Add code
- [x] Change/Remove code
- [x] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
All calc_static_head tests passing

### Docstring: calc_static_head
![static_calc_static_head](https://user-images.githubusercontent.com/50923525/132410232-ca291f38-d6e2-4193-bd20-473237fd120c.png)

### Docstring: calc_head_offset
![static_calc_head_offset](https://user-images.githubusercontent.com/50923525/132410243-5616e630-7982-4c0f-a3b3-d8a9c98a608c.png)



