### PR TITLE
Refactor kinetics findL5_Pelvis to 4x4 version

### DIFF
--- a/pyCGM_Single/pycgmKinetics.py
+++ b/pyCGM_Single/pycgmKinetics.py
@@ -292,22 +292,22 @@ def pnt2line(pnt, start, end):
 
 
 def calc_l5_pelvis(rhip, lhip, pelvis_axis):
-    """Calculate L5 Markers given Pelvis Axis
+    """Calculate L5 Markers given Pelvis Axis.
 
     Markers used: RHip, LHip
 
     Parameters
     ----------
-    rhip: array
+    rhip : array
         1x3 RHip marker
-    lhip: array
+    lhip : array
         1x3 LHip marker
     pelvis_axis : array
         4x4 affine matrix containing the pelvis (x, y, z) axes and origin.
 
     Returns
     -------
-    midHip, L5 : tuple
+    midHip, L5 : array
         2x3 array containing the (x, y, z) positions of the midHip and L5 markers
 
     Examples

--- a/pyCGM_Single/pycgmKinetics.py
+++ b/pyCGM_Single/pycgmKinetics.py
@@ -291,54 +291,54 @@ def pnt2line(pnt, start, end):
 #        return np.nan
 
 
-def findL5_Pelvis(frame):
-    """Calculate L5 Markers Given Pelvis function
+def calc_l5_pelvis(rhip, lhip, pelvis_axis):
+    """Calculate L5 Markers
 
-    Markers used: `LHip`, `RHip`, `Pelvis_axis`
+    Markers used: RHIP, LHIP
 
     Parameters
     ----------
-    frame : dict
-        Dictionaries of marker lists.
+    rhip: array
+        1x3 RHIP marker
+    lhip: array
+        1x3 LHIP marker
+    pelvis_axis : array
+        4x4 affine matrix containing the pelvis (x, y, z) axes and origin.
 
     Returns
     -------
     midHip, L5 : tuple
-        Returns the (x, y, z) marker positions of the midHip, a (1x3) array,
-        and L5, a (1x3) array, in a tuple.
+        2x3 array containing the (x, y, z) positions of the midHip and L5 markers
 
     Examples
     --------
     >>> import numpy as np
-    >>> from .pycgmKinetics import findL5_Pelvis
-    >>> Pelvis_axis = [np.array([251.60, 391.74, 1032.89]),
-    ...                np.array([[251.74, 392.72, 1032.78],
-    ...                    [250.61, 391.87, 1032.87],
-    ...                    [251.60, 391.84, 1033.88]]),
-    ...                np.array([231.57, 210.25, 1052.24])]
-    >>> LHip = np.array([308.38, 322.80, 937.98])
-    >>> RHip = np.array([182.57, 339.43, 935.52])
-    >>> frame = { 'Pelvis_axis': Pelvis_axis, 'RHip': RHip, 'LHip': LHip}
-    >>> np.around(findL5_Pelvis(frame), 2) #doctest: +NORMALIZE_WHITESPACE
+    >>> from .pycgmKinetics import calc_l5_pelvis
+    >>> lhip = np.array([308.38, 322.80, 937.98])
+    >>> rhip = np.array([182.57, 339.43, 935.52])
+    >>> pelvis_axis = np.array([[251.74, 392.72, 1032.78,  251.60],
+    ...                         [250.61, 391.87, 1032.87,  391.74],
+    ...                         [251.60, 391.84, 1033.88, 1032.89],
+    ...                         [  0,      0,       0,       0   ]])
+    >>> np.around(calc_l5_pelvis(rhip, lhip, pelvis_axis), 2) #doctest: +NORMALIZE_WHITESPACE
     array([[ 245.48,  331.12,  936.75],
            [ 271.53,  371.69, 1043.8 ]])
     """
-    #The L5 position is estimated as (LHJC + RHJC)/2 +
-    #(0.0, 0.0, 0.828) * Length(LHJC - RHJC), where the value 0.828
-    #is a ratio of the distance from the hip joint centre level to the
-    #top of the lumbar 5: this is calculated as in teh vertical (z) axis
-    LHJC = frame['LHip']
-    RHJC = frame['RHip']
-    midHip = (LHJC+RHJC)/2
-    #zOffset = ([0.0,0.0,distance(RHJC, LHJC)*0.925])
-    #L5 = midHip + zOffset
 
-    offset = distance(RHJC,LHJC) * .925
-    z_axis = frame['Pelvis_axis'][1][2]
+    rhip, lhip, pelvis_axis = map(np.asarray, [rhip, lhip, pelvis_axis])
+
+    # The L5 position is estimated as (LHJC + RHJC)/2 +
+    # (0.0, 0.0, 0.828) * Length(LHJC - RHJC), where the value 0.828
+    # is a ratio of the distance from the hip joint centre level to the
+    # top of the lumbar 5: this is calculated as in the vertical (z) axis
+    midHip = (lhip + rhip) / 2
+
+    offset = distance(rhip, lhip) * .925
+    z_axis = pelvis_axis[2, :3]
     norm_dir = np.array(unit(z_axis))
-    L5 = midHip + offset * norm_dir
+    l5 = midHip + offset * norm_dir
 
-    return midHip, L5#midHip + ([0.0, 0.0, zOffset])
+    return [midHip, l5]
 
 def findL5_Thorax(frame):
     """Calculate L5 Markers Given Thorax function.

--- a/pyCGM_Single/pycgmKinetics.py
+++ b/pyCGM_Single/pycgmKinetics.py
@@ -292,16 +292,16 @@ def pnt2line(pnt, start, end):
 
 
 def calc_l5_pelvis(rhip, lhip, pelvis_axis):
-    """Calculate L5 Markers
+    """Calculate L5 Markers given Pelvis Axis
 
-    Markers used: RHIP, LHIP
+    Markers used: RHip, LHip
 
     Parameters
     ----------
     rhip: array
-        1x3 RHIP marker
+        1x3 RHip marker
     lhip: array
-        1x3 LHIP marker
+        1x3 LHip marker
     pelvis_axis : array
         4x4 affine matrix containing the pelvis (x, y, z) axes and origin.
 

--- a/pyCGM_Single/tests/test_pycgmKinetics.py
+++ b/pyCGM_Single/tests/test_pycgmKinetics.py
@@ -488,44 +488,52 @@ class Test_pycgmKinetics(TestCase):
             with self.assertRaises(Exception):
                 pycgmKinetics.pnt2line(e[0],e[1],e[2])
     
-    def test_findL5_Pelvis(self):
+    def test_calc_l5_pelvis(self):
         """
-        This test provides coverage of the findL5_Pelvis function in pycgmKinetics.py,
-        defined as findL5_Pelvis(frame), where frame contains the markers: LHip, RHip, and Pelvis_axis.
+        This test provides coverage of the calc_l5_pelvis function in pycgmKinetics.py,
+        defined as calc_l5_pelvis(rhip, lhip, pelvis_axis):
 
-        Each index in accuracyTests is used as parameters for the function findL5_Pelvis 
+        Each index in test_parameters is used as parameters for the function calc_l5_pelvis 
         and the result is then checked to be equal with the same index in 
-        accuracyResults using 8 decimal point precision comparison.
+        test_results using 8 decimal point precision comparison.
         """
         # Test 3 different frames that contain different markers for LHip, RHip, and Pelvis_axis.
-        accuracyTests=[]
-        frame={}
-        frame['Pelvis_axis'] = [np.array([151.60830688, 291.74131775, 832.89349365]), np.array([[251.74063624, 392.72694721, 1032.78850073], [250.61711554, 391.87232862, 1032.8741063], [251.60295336, 391.84795134, 1033.88777762]]), np.array([231.57849121, 210.25262451, 1052.24969482])]
-        frame['RHip'] = np.array([208.38050472, 122.80342417, 437.98979061])
-        frame['LHip'] = np.array([282.57097863, 139.43231855, 435.52900012])
-        accuracyTests.append(frame)
 
-        frame=dict()
-        frame['Pelvis_axis'] = [np.array([-553.90052549, -327.14438741, -4.58459872]), np.array([[586.81782059, 994.852335, -164.15032491], [367.53692416, -193.11814502, 141.95648112], [814.64795266, 681.51439276, 87.63894117]]), np.array([424.76800206, 817.17612395, 850.60552074])]
-        frame['RHip'] = np.array([-570.727107, 409.48579719, 387.17336605])
-        frame['LHip'] = np.array([984.96369008, 161.72241084, 714.78280362])
-        accuracyTests.append(frame)
+        test_parameters=[]
 
-        frame=dict()
-        frame['Pelvis_axis'] = [np.array([691.47208667, 395.90359428, 273.23978111]), np.array([[711.02920886, -701.16459687, 532.55441473], [-229.76970935, -650.15236712, 359.70108366], [222.81186893, 536.56366268, 386.21334066]]), np.array([102.63381498, 638.27698716, 806.02729965])]
-        frame['RHip'] = np.array([-651.87182756, -493.94862894, 640.38910712])
-        frame['LHip'] = np.array([624.42435686, 746.90148656, -603.71552902])
-        accuracyTests.append(frame)
+        rhip = np.array([208.38050472, 122.80342417, 437.98979061])
+        lhip = np.array([282.57097863, 139.43231855, 435.52900012])
+        pelvis_axis = np.array([[251.74063624, 392.72694721, 1032.78850073, 151.60830688],
+                                [250.61711554, 391.87232862, 1032.8741063,  291.74131775],
+                                [251.60295336, 391.84795134, 1033.88777762, 832.89349365],
+                                [  0,            0,             0,            0         ]])
+        test_parameters.append([rhip, lhip, pelvis_axis])
 
-        accuracyResults=[
+        rhip = np.array([-570.727107, 409.48579719, 387.17336605])
+        lhip = np.array([984.96369008, 161.72241084, 714.78280362])
+        pelvis_axis = np.array([[586.81782059,  994.852335,  -164.15032491,  553.90052549],
+                                [367.53692416, -193.11814502, 141.95648112, -327.14438741],
+                                [814.64795266,  681.51439276,  87.63894117,   -4.58459872],
+                                [  0,             0,            0,             0         ]])
+        test_parameters.append([rhip, lhip, pelvis_axis])
+
+        rhip = np.array([-651.87182756, -493.94862894, 640.38910712])
+        lhip = np.array([624.42435686, 746.90148656, -603.71552902])
+        pelvis_axis = np.array([[ 711.02920886, -701.16459687, 532.55441473, 691.47208667],
+                                [-229.76970935, -650.15236712, 359.70108366, 395.90359428],
+                                [ 222.81186893,  536.56366268, 386.21334066, 273.23978111],
+                                [   0,             0,            0,            0         ]])
+        test_parameters.append([rhip, lhip, pelvis_axis])
+
+        test_results=[
             ([[245.4757417, 131.1178714, 436.7593954],[261.0890402, 155.4341163, 500.9176188]]),
             ([[207.1182915, 285.604104 , 550.9780848],[1344.7944079, 1237.3558945,  673.3680447]]),
             ([[-13.7237354, 126.4764288,  18.3367891],[ 627.8602897, 1671.5048695, 1130.4333341]])
         ]
-        for i in range(len(accuracyTests)):
-            # Call findL5_Pelvis(frame) with each frame in accuracyTests and round each variable in the 3-element returned list.
-            result = [np.around(arr,rounding_precision) for arr in pycgmKinetics.findL5_Pelvis(accuracyTests[i])]
-            expected = list(accuracyResults[i])
+        for i in range(len(test_parameters)):
+            # Call calc_l5_pelvis(frame) with each frame in test_parameters and round each variable in the 3-element returned list.
+            result = [np.around(arr,rounding_precision) for arr in pycgmKinetics.calc_l5_pelvis(*test_parameters[i])]
+            expected = list(test_results[i])
             for j in range(len(result)):
                 np.testing.assert_almost_equal(result[j], expected[j])
     


### PR DESCRIPTION
### Summary of PR:
Refactor findL5Pelvis to calc_l5_pelvis.

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- pycgmKinetics.py - Refactor function
- test_pycgmKinetics.py - Refactor test

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [x] Change/Remove tests
- [ ] Add code
- [x] Change/Remove code
- [x] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
All calc_l5_pelvis tests passing

### Docstring: calc_l5_pelvis
![kinetics_calc_l5_pelvis](https://user-images.githubusercontent.com/50923525/133020500-5cf9dacb-c3cf-4e2a-a6be-9a72a085edb5.png)



