### PR TITLE
Replace pre-refactor function names in test class docstrings

### DIFF
--- a/pyCGM_Single/tests/test_pycgmStatic_axis.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_axis.py
@@ -16,7 +16,7 @@ class TestPycgmStaticAxis():
         calc_axis_head
         calc_axis_uncorrect_foot
         calc_axis_flatfoot
-        rotaxis_nonfootflat
+        calc_axis_nonflatfoot
         calc_joint_center
     """
     nan_3d = [np.nan, np.nan, np.nan]

--- a/pyCGM_Single/tests/test_pycgmStatic_utils.py
+++ b/pyCGM_Single/tests/test_pycgmStatic_utils.py
@@ -17,9 +17,9 @@ class TestPycgmStaticUtils():
     getStatic
     average
     calc_IAD
-    headoffCalc
-    staticCalculation
-    getankleangle
+    calc_head_offset
+    calc_foot_offset
+    calc_static_angle_ankle
     norm2d
     norm3d
     normDiv

--- a/pyCGM_Single/tests/test_pycgm_angle.py
+++ b/pyCGM_Single/tests/test_pycgm_angle.py
@@ -8,11 +8,10 @@ rounding_precision = 6
 class TestPycgmAngle():
     """
     This class tests the functions used for getting angles in pyCGM.py:
-    getangle_sho
-    getangle_spi
-    getangle
-    getHeadangle
-    getPelangle
+    calc_angle_shoulder
+    calc_angle_spine
+    calc_angle
+    calc_angle_head
     """
 
     @pytest.mark.parametrize(

--- a/pyCGM_Single/tests/test_pycgm_axis.py
+++ b/pyCGM_Single/tests/test_pycgm_axis.py
@@ -8,7 +8,7 @@ rounding_precision = 5
 class TestUpperBodyAxis():
     """
     This class tests the upper body axis functions in pyCGM.py:
-        headJC
+        calc_axis_head
         calc_axis_thorax
         calc_joint_center_shoulder
         calc_axis_shoulder
@@ -5462,7 +5462,7 @@ class TestLowerBodyAxis():
 class TestAxisUtils():
     """
     This class tests the lower body axis functions in pyCGM.py:
-    findJointC
+    calc_joint_center
     JointAngleCalc
     """
 


### PR DESCRIPTION
### Summary of PR:
Replace old function names in test class docstrings.

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- test_pycgmStatic_axis.py - Above docstring changes
- test_pycgmStatic_utils.py - Above docstring changes
- test_pycgm_angle.py - Above docstring changes
- test_pycgm_axis.py - Above docstring changes

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [x] Change/Remove tests
- [ ] Add code
- [ ] Change/Remove code
- [x] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
Code unchanged

