### PR TITLE
Pass subject measurement values directly to calc_joint_center_hip

### DIFF
--- a/pyCGM_Single/pyCGM.py
+++ b/pyCGM_Single/pyCGM.py
@@ -144,7 +144,7 @@ def calc_axis_pelvis(rasi, lasi, rpsi, lpsi, sacr=None):
     return pelvis
 
 
-def calc_joint_center_hip(pelvis, subject):
+def calc_joint_center_hip(pelvis, mean_leg_length, right_asis_to_trochanter, left_asis_to_trochanter, inter_asis_distance):
     u"""Calculate the right and left hip joint center.
 
     Takes in a 4x4 affine matrix of pelvis axis and subject measurements
@@ -186,15 +186,17 @@ def calc_joint_center_hip(pelvis, subject):
     >>> import numpy as np
     >>> np.set_printoptions(suppress=True)
     >>> from .pyCGM import calc_joint_center_hip
-    >>> vsk = {'MeanLegLength': 940.0, 'R_AsisToTrocanterMeasure': 72.51,
-    ...        'L_AsisToTrocanterMeasure': 72.51, 'InterAsisDistance': 215.90}
+    >>> mean_leg_length = 940.0 
+    >>> right_asis_to_trochanter = 72.51
+    >>> left_asis_to_trochanter = 72.51
+    >>> inter_asis_distance = 215.90
     >>> pelvis_axis = np.array([
     ...     [0.14, 0.98, -0.11, 251.60],
     ...     [-0.99, 0.13, -0.02, 391.74],
     ...     [0, 0.1, 0.99, 1032.89],
     ...     [0, 0, 0, 1]
     ... ])
-    >>> np.around(calc_joint_center_hip(pelvis_axis,vsk), 2) #doctest: +NORMALIZE_WHITESPACE
+    >>> np.around(calc_joint_center_hip(pelvis_axis, mean_leg_length, right_asis_to_trochanter, left_asis_to_trochanter, inter_asis_distance), 2) #doctest: +NORMALIZE_WHITESPACE
     array([[307.36, 323.83, 938.72],
            [181.71, 340.33, 936.18]])
     """
@@ -216,14 +218,10 @@ def calc_joint_center_hip(pelvis, subject):
     # Half of marker size
     mm = 7.0
 
-    mean_leg_length = subject['MeanLegLength']
-    right_asis_to_trochanter = subject['R_AsisToTrocanterMeasure']
-    left_asis_to_trochanter = subject['L_AsisToTrocanterMeasure']
-    interAsisMeasure = subject['InterAsisDistance']
     C = (mean_leg_length * 0.115) - 15.3
     theta = 0.500000178813934
     beta = 0.314000427722931
-    aa = interAsisMeasure/2.0
+    aa = inter_asis_distance/2.0
     S = -1
 
     # Hip Joint Center Calculation (ref. Davis_1991)
@@ -2592,7 +2590,12 @@ def JointAngleCalc(frame,vsk):
     pely = global_pelvis_angle[1]
     pelz = global_pelvis_angle[2]
 
-    hip_jc = calc_joint_center_hip(pelvis_axis, vsk)
+    hip_jc = calc_joint_center_hip(pelvis_axis, 
+                                   vsk["MeanLegLength"], 
+                                   vsk["R_AsisToTrocanterMeasure"],
+                                   vsk["L_AsisToTrocanterMeasure"],
+                                   vsk["InterAsisDistance"])
+    
     r_hip_jc = hip_jc[0]
     l_hip_jc = hip_jc[1]
 

--- a/pyCGM_Single/tests/test_pycgm_axis.py
+++ b/pyCGM_Single/tests/test_pycgm_axis.py
@@ -3602,7 +3602,7 @@ class TestLowerBodyAxis():
     def test_calc_joint_center_hip(self, pelvis_axis, subject, expected):
         """
         This test provides coverage of the calc_joint_center_hip function in pyCGM.py,
-        defined as calc_joint_center_hip(pelvis_axis, subject)
+        defined as calc_joint_center_hip(pelvis, mean_leg_length, right_asis_to_trochanter, left_asis_to_trochanter, inter_asis_distance)
 
         This test takes 2 parameters:
         pelvis_axis: 4x4 affine matrix representing the pelvis axes and origin
@@ -3618,6 +3618,10 @@ class TestLowerBodyAxis():
         Lastly, it checks that the resulting output is correct when the pelvis axis is composed of lists of ints, 
         numpy arrays of ints, lists of floats, and numpy arrays of floats and vsk values are ints or floats.
         """
+        mean_leg_length = subject["MeanLegLength"]
+        right_asis_to_trochanter = subject["R_AsisToTrocanterMeasure"]
+        left_asis_to_trochanter = subject["L_AsisToTrocanterMeasure"]
+        inter_asis_distance = subject["InterAsisDistance"]
 
         pelvis_axis = np.asarray(pelvis_axis)
         pelvis_o = pelvis_axis[:3, 3]
@@ -3625,7 +3629,7 @@ class TestLowerBodyAxis():
         pelvis_axis[1, :3] -= pelvis_o
         pelvis_axis[2, :3] -= pelvis_o
 
-        result = pyCGM.calc_joint_center_hip(pelvis_axis, subject)
+        result = pyCGM.calc_joint_center_hip(pelvis_axis, mean_leg_length, right_asis_to_trochanter, left_asis_to_trochanter, inter_asis_distance)
         np.testing.assert_almost_equal(result, expected, rounding_precision)
 
     @pytest.mark.parametrize(["l_hip_jc", "r_hip_jc", "pelvis_axis", "expected"], [


### PR DESCRIPTION
### Summary of PR:
Pass subject measurement values directly to the already refactored `calc_joint_center_hip`

### What issues does this PR close:
Refactor, Documentation

### What files were changed and what changes were made?
- pyCGM.py - Modify function to take in vsk values, function call
- test_pycgm_axis.py - Modify tests to pass vsk values

### Does your PR (check all that applies):
- [ ] Add documentation
- [x] Change/Remove documentation
- [ ] Add tests
- [x] Change/Remove tests
- [ ] Add code
- [x] Change/Remove code
- [ ] Fix formatting

### Are there any errors/relevant logs in your code?
None

### How has this been tested?
Tests still passing

