### PR TITLE
Build Sphinx docs for static and dynamic code

### DIFF
--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -1,9 +1,10 @@
 API for pycgm
 =============
 
-.. currentmodule:: pycgm
+.. currentmodule:: pyCGM_Single
 
 .. autosummary::
    :toctree: generated/
 
-   axis
+   pycgmStatic
+   pyCGM


### PR DESCRIPTION
Allow Sphinx to build docs for static and dynamic files in pyCGM_Single