### PR TITLE
Remove old code from Pipelines test

### DIFF
--- a/pyCGM_Single/tests/test_Pipelines.py
+++ b/pyCGM_Single/tests/test_Pipelines.py
@@ -274,7 +274,7 @@ class TestPipelinesGapFilling:
         cls.data_original = dataAsDict(motionData, npArray=True)
         cls.static_original = dataAsDict(staticData, npArray=True)
         for frame in motionData:
-            frame['SACR'] = (frame['RPSI'] + frame['LPSI']) / 2.0
+            frame['SACR'] = frame['SACR'] if 'SACR' in frame else (frame['RPSI'] + frame['LPSI']) / 2.0
         cls.data_with_sacrum_original = dataAsDict(motionData, npArray=True)
         Pipelines.clearMarker(motionData, 'LFHD')
         cls.data_with_sacrum_clear_marker = dataAsDict(motionData, npArray=True)

--- a/pyCGM_Single/tests/test_Pipelines.py
+++ b/pyCGM_Single/tests/test_Pipelines.py
@@ -3,7 +3,6 @@ import numpy as np
 from pyCGM_Single.pyCGM_Helpers import getfilenames
 from pyCGM_Single.pycgmIO import loadData, dataAsDict
 from pyCGM_Single.clusterCalc import target_dict, segment_dict
-from pyCGM_Single.pyCGM import pelvisJointCenter
 import pyCGM_Single.Pipelines as Pipelines
 import os
 import mock 
@@ -275,7 +274,7 @@ class TestPipelinesGapFilling:
         cls.data_original = dataAsDict(motionData, npArray=True)
         cls.static_original = dataAsDict(staticData, npArray=True)
         for frame in motionData:
-            frame['SACR'] = pelvisJointCenter(frame)[2]
+            frame['SACR'] = (frame['RPSI'] + frame['LPSI']) / 2.0
         cls.data_with_sacrum_original = dataAsDict(motionData, npArray=True)
         Pipelines.clearMarker(motionData, 'LFHD')
         cls.data_with_sacrum_clear_marker = dataAsDict(motionData, npArray=True)


### PR DESCRIPTION
Remove the import and usage of `pelvisJointCenter` to calculate the sacrum marker in `test_Pipelines.py`. Replace with the calculation that was inside the old function: `(RPSI + LPSI) / 2.0`.