### PR TITLE
Round writeResult test to 11 decimal places

### DIFF
--- a/pyCGM_Single/tests/test_pycgmIO.py
+++ b/pyCGM_Single/tests/test_pycgmIO.py
@@ -522,7 +522,7 @@ class TestPycgmIO:
             array_result = np.asarray(result, dtype=np.float64)
             len_result = len(array_result)
             #Test that the truncated results are equal
-            np.testing.assert_equal(truncated_result, array_result[:7])
+            np.testing.assert_almost_equal(truncated_result, array_result[:7], 11)
             #Test we have written the correct number of results
             np.testing.assert_equal(len_result, len_written)
         


### PR DESCRIPTION
Round the assertion in the pycgmIO `writeResult` test to 11 decimal places. The test's expected values come from the pre-refactor output of `jointAngleCalc`, which seems to now be accurate to 11 decimal places.