### PR TITLE
Suppress loadData scientific notation

### DIFF
--- a/pyCGM_Single/pycgmIO.py
+++ b/pyCGM_Single/pycgmIO.py
@@ -646,6 +646,7 @@ def loadData(filename, rawData=True):
         RoboResults.csv and RoboResults.c3d in SampleData are used to
         test the output.
 
+        >>> np.set_printoptions(suppress=True)
         >>> csvFile = 'SampleData/Sample_2/RoboResults.csv'
         >>> c3dFile = 'SampleData/Sample_2/RoboStatic.c3d'
         >>> csvData = loadData(csvFile)


### PR DESCRIPTION
We expect `array([-220.68171692,   -1.07236075, 1455.51550293])`, not `array([-2.20681717e+02, -1.07236075e+00,  1.45551550e+03])`
